### PR TITLE
Fix windows and non-pkgconfig builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ a few unsafe API's as well that expose more nitty-gritty.
 
 This repo currently works on at least Linux, but may work on other OS's as
 well.  You will need OpenEXR and zlib installed on your system.  You can
-specify the paths where the libraries are with the OPENEXR_LIBRARY and
-ZLIB_LIBRARY environment variables.  Otherwise pkgconfig will be used to
+specify the prefixes the libraries are installed to with the OPENEXR_DIR and
+ZLIB_DIR environment variables.  If unset, pkgconfig will be used to
 try to find the libraries automatically.
 
 The beginnings of bindings to the scanline input/output classes are there

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ a few unsafe API's as well that expose more nitty-gritty.
 
 ## Status
 
-This repo currently works on at least Linux, but may work on other OS's as
-well.  You will need OpenEXR and zlib installed on your system.  You can
-specify the prefixes the libraries are installed to with the OPENEXR_DIR and
-ZLIB_DIR environment variables.  If unset, pkgconfig will be used to
-try to find the libraries automatically.
+This repo currently works on at least Linux, but may work on other OS's as well.
+You will need OpenEXR and zlib installed on your system.  You can specify the
+prefixes the libraries are installed to with the ILMBASE_DIR, OPENEXR_DIR, and
+ZLIB_DIR environment variables.  Depending on how your OpenEXR was built, you
+may need to set OPENEXR_LIB_SUFFIX to a value such as "2_2". If an _DIR variable
+is unset, pkgconfig will be used to try to find the corresponding library
+automatically.
 
 The beginnings of bindings to the scanline input/output classes are there
 and partially working.  These bindings are not yet useful for anything,

--- a/README.md
+++ b/README.md
@@ -13,23 +13,23 @@ Convenient and safe API's will be provided for most functionality.  However,
 to provide the full flexibility of the underlying C++ library, there may be
 a few unsafe API's as well that expose more nitty-gritty.
 
-## Status
+## Using
 
-This repo currently works on at least Linux, but may work on other OS's as well.
-You will need OpenEXR and zlib installed on your system.  You can specify the
+You will need builds of OpenEXR and zlib available.  You can specify the
 prefixes the libraries are installed to with the ILMBASE_DIR, OPENEXR_DIR, and
 ZLIB_DIR environment variables.  Depending on how your OpenEXR was built, you
-may need to set OPENEXR_LIB_SUFFIX to a value such as "2_2". If an _DIR variable
-is unset, pkgconfig will be used to try to find the corresponding library
-automatically.
+may also need to set OPENEXR_LIB_SUFFIX to a value such as "2_2".  If an _DIR
+variable is unset, pkgconfig will be used to try to find the corresponding
+library automatically.
 
-The beginnings of bindings to the scanline input/output classes are there
-and partially working.  These bindings are not yet useful for anything,
-but we're working on it!
+## Status
+
+This library has been tested on Linux and Windows.  Basic I/O is supported,
+including reading from memory.
 
 ## TODO
 
-- [ ] Wrap basic scanline output.
+- [x] Wrap basic scanline output.
 - [x] Wrap basic scanline input.
 - [ ] Figure out a good way to support Half floats.
 - [ ] Make simple convenience functions for basic RGB/RGBA input and output.

--- a/openexr-sys/build.rs
+++ b/openexr-sys/build.rs
@@ -9,11 +9,17 @@ fn main() {
     let include_paths = {
         let mut include_paths = Vec::new();
 
+        let suffix = if let Ok(v) = env::var("OPENEXR_LIB_SUFFIX") {
+            format!("-{}", v)
+        } else {
+            "".into()
+        };
+
         if let Ok(path) = env::var("OPENEXR_DIR") {
             // There's an environment variable, so let's use that
             println!("cargo:rustc-link-search=native={}/lib", path);
-            println!("cargo:rustc-link-lib=static=IlmImf");
-            println!("cargo:rustc-link-lib=static=IlmImfUtil");
+            println!("cargo:rustc-link-lib=static=IlmImf{}", suffix);
+            println!("cargo:rustc-link-lib=static=IlmImfUtil{}", suffix);
             include_paths.push(PathBuf::from(&format!("{}/include/OpenEXR", path)));
         } else {
             // There's no enviroment variable, so use pkgconfig to find
@@ -34,10 +40,10 @@ fn main() {
 
         if let Ok(path) = env::var("ILMBASE_DIR") {
             println!("cargo:rustc-link-search=native={}/lib", path);
-            println!("cargo:rustc-link-lib=static=IexMath");
-            println!("cargo:rustc-link-lib=static=Iex");
-            println!("cargo:rustc-link-lib=static=Imath");
-            println!("cargo:rustc-link-lib=static=IlmThread");
+            println!("cargo:rustc-link-lib=static=IexMath{}", suffix);
+            println!("cargo:rustc-link-lib=static=Iex{}", suffix);
+            println!("cargo:rustc-link-lib=static=Imath{}", suffix);
+            println!("cargo:rustc-link-lib=static=IlmThread{}", suffix);
             println!("cargo:rustc-link-lib=static=Half");
             include_paths.push(PathBuf::from(&format!("{}/include/OpenEXR", path)));
         } else {

--- a/openexr-sys/build.rs
+++ b/openexr-sys/build.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 fn main() {
     // Find and link OpenEXR and IlmBase
-    let include_paths = if let Ok(path) = env::var("OPENEXR_LIBRARY") {
+    let include_paths = if let Ok(path) = env::var("OPENEXR_DIR") {
         // There's an environment variable, so let's use that
         println!("cargo:rustc-link-search=native={}/lib", path);
         println!("cargo:rustc-link-lib=static=IlmImf-2_2");
@@ -26,7 +26,7 @@ fn main() {
             .map(|openexr_cfg| openexr_cfg.include_paths.clone())
             .map_err(|err| {
                          panic!("couldn't find OpenEXR: environment variable \
-                OPENEXR_LIBRARY is unset and pkg-config failed: {}",
+                OPENEXR_DIR is unset and pkg-config failed: {}",
                                 err)
                      })
             .unwrap();
@@ -38,7 +38,7 @@ fn main() {
             .map(|ilmbase_cfg| ilmbase_cfg.include_paths.clone())
             .map_err(|err| {
                          panic!("couldn't find IlmBase: environment variable \
-                OPENEXR_LIBRARY is unset and pkg-config failed: {}",
+                OPENEXR_DIR is unset and pkg-config failed: {}",
                                 err)
                      })
             .unwrap();
@@ -51,11 +51,11 @@ fn main() {
 
     // Find and link zlib, needed for OpenEXR
     // Use environment variable if it exists, and otherwise use pkgconfig.
-    if let Ok(path) = env::var("ZLIB_LIBRARY") {
-        println!("cargo:rustc-link-search=native={}", path);
+    if let Ok(path) = env::var("ZLIB_DIR") {
+        println!("cargo:rustc-link-search=native={}/lib", path);
         println!("cargo:rustc-link-lib=static=zlibstatic");
     } else if let Err(err) = pkg_config::probe_library("zlib") {
-        panic!("couldn't find zlib: environment variable ZLIB_LIBRARY is unset \
+        panic!("couldn't find zlib: environment variable ZLIB_DIR is unset \
             and pkg-config failed: {}",
                err);
     }

--- a/openexr-sys/c_wrapper/cexr.cpp
+++ b/openexr-sys/c_wrapper/cexr.cpp
@@ -32,8 +32,8 @@ void CEXR_IStream_delete(CEXR_IStream *stream) {
 //----------------------------------------------------
 // Header
 
-CEXR_Header* CEXR_Header_new(CEXR_Box2i *displayWindow,
-                             CEXR_Box2i *dataWindow,
+CEXR_Header* CEXR_Header_new(const CEXR_Box2i *displayWindow,
+                             const CEXR_Box2i *dataWindow,
                              float pixelAspectRatio,
                              const CEXR_V2f *screenWindowCenter,
                              float screenWindowWidth,

--- a/openexr-sys/c_wrapper/cexr.cpp
+++ b/openexr-sys/c_wrapper/cexr.cpp
@@ -2,15 +2,15 @@
 
 #include <cstdint>
 #include <cstddef>
-#include "OpenEXR/ImathVec.h"
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImfPixelType.h"
-#include "OpenEXR/ImfChannelList.h"
-#include "OpenEXR/ImfHeader.h"
-#include "OpenEXR/ImfFrameBuffer.h"
-#include "OpenEXR/ImfOutputFile.h"
-#include "OpenEXR/ImfInputFile.h"
-#include "OpenEXR/Iex.h"
+#include "ImathVec.h"
+#include "ImathBox.h"
+#include "ImfPixelType.h"
+#include "ImfChannelList.h"
+#include "ImfHeader.h"
+#include "ImfFrameBuffer.h"
+#include "ImfOutputFile.h"
+#include "ImfInputFile.h"
+#include "Iex.h"
 
 #include "memory_istream.hpp"
 

--- a/openexr-sys/c_wrapper/cexr.h
+++ b/openexr-sys/c_wrapper/cexr.h
@@ -60,11 +60,11 @@ typedef struct CEXR_IStream CEXR_IStream;
 CEXR_IStream *CEXR_IStream_from_memory(const char *filename, char *data, size_t size);
 void CEXR_IStream_delete(CEXR_IStream *stream);
 CEXR_Header *CEXR_Header_new(const CEXR_Box2i *displayWindow,
-	                         const CEXR_Box2i *dataWindow,
-	                         float pixelAspectRatio,
-	                         const CEXR_V2f *screenWindowCenter,
-	                         float screenWindowWidth,
-	                         CEXR_LineOrder lineOrder,
+                             const CEXR_Box2i *dataWindow,
+                             float pixelAspectRatio,
+                             const CEXR_V2f *screenWindowCenter,
+                             float screenWindowWidth,
+                             CEXR_LineOrder lineOrder,
                              CEXR_Compression compression);
 void CEXR_Header_delete(CEXR_Header *header);
 const CEXR_Box2i *CEXR_Header_display_window(const CEXR_Header *header);

--- a/openexr-sys/c_wrapper/memory_istream.hpp
+++ b/openexr-sys/c_wrapper/memory_istream.hpp
@@ -1,7 +1,7 @@
 #ifndef CEXR_MEMORY_ISTREAM_H_
 #define CEXR_MEMORY_ISTREAM_H_
 
-#include "OpenEXR/ImfIO.h"
+#include "ImfIO.h"
 
 #include <cstddef>
 


### PR DESCRIPTION
Previously, FOO_LIBRARY was being used inconsistently to refer to either the prefix or lib directory of a library. This change normalizes both cases to use prefixes, and adjusts names to suit.

Also fix a bunch of minor issues preventing use in various environments.