### PR TITLE
Cache OpenEXR/IlmBase build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,56 @@
 language: rust
-sudo: required
 rust:
 - stable
 - beta
 - nightly
 env:
   global:
-    - OPENEXR_DIR=/usr/local
-    - ILMBASE_DIR=/usr/local
-    - OPENEXR_LIB_SUFFIX=2_2
+    - MAKEFLAGS="-j 2"
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - secure: HymLL+xGbR8WmBN7j5c/dNgCZ7WtLInNNDyqQKYA3Y0bEDTF4s26Q06YDrEuJtIsAvXCBxiNxONb4PYTqXTOBl6chc8BXGQoRx7tQBo9KXlV4DLwGiKSpl5/tmDsBXublFGAO1hh+tXjhgL6vA2kgLfvHq3rYV2eEioGEHXC4UOxdbEgPLeZ2FxqZrQuG9b4+tL8hjUuvZP26NgR23y80nnubAoiJb/qSwgtDdDaslBpU7/kQI5HU6C3Kt45feIGFhmYAPNVUjV4DyzT7d3tvZopcITTlBqMDAgYj0bYUF79c6FSQ7iDVJAh4ZQ3G0hXvzTe5IIaQ+BazG8yNSm4RY4R9MS0SkiVKT82LXYEtglPDO0QFL753QxGktkSfPFwhqK9AFIyJYXDGehqhpfA9ZR4innMANejWYNE5MB0XfSPuUsl2yKsxwoEWeDx5BkiiZj0IhwqAb2Y6fHdVgRMdsOVUHm06BMzVmBgVed0SNzdrfaqECxH5uIbGPWShiTJQmD82y2Bf/0qYPe42mNpAdEIcW6/Kf+emZMhkwS1a7W9Kkls6k8LykdJxQ00Ico6OTQd2Zr3t99aQQ3uRpQwkDS2Qo1GV2P3BGnkhUEesZxKctfYVpHFg+5F5eVOQ4knZskLQW5ha0dTnX8jIjdFnJQU36M1psrt4fdkTgwc44A=
 
 before_install:
-- wget https://github.com/openexr/openexr/archive/v2.2.0.tar.gz -O openexr2.2.tar.gz
-- tar xzf openexr2.2.tar.gz
-- pushd openexr-2.2.0/IlmBase && cmake -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC"
-  -DCMAKE_INSTALL_PREFIX=/usr/local ./ && make && sudo make install && popd
-- pushd openexr-2.2.0/IlmBase && rm CMakeCache.txt && cmake -DCMAKE_C_FLAGS="-fPIC"
-  -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_SHARED_LIBS=OFF
-  ./ && make && sudo make install && popd
-- pushd openexr-2.2.0/OpenEXR && cmake -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC"
-  -DCMAKE_INSTALL_PREFIX=/usr/local -DILMBASE_PACKAGE_PREFIX=/usr/local -DBUILD_SHARED_LIBS=OFF
-  ./ && make && sudo make install && popd
+- |
+  ILMBASE_DIR="$PWD/ilmbase"
+  OPENEXR_DIR="$PWD/openexr"
+  if [ ! -d "$OPENEXR_DIR/include" ]; then
+    wget https://github.com/openexr/openexr/archive/v2.2.0.tar.gz -O- |tar xz
+    pushd openexr-2.2.0
+
+    pushd IlmBase
+    ./bootstrap
+    mkdir build
+    pushd build
+    ../configure --enable-static=yes --enable-shared=no --with-pic --prefix="$ILMBASE_DIR" && make && make install
+    popd
+    popd
+
+    pushd OpenEXR
+    ./bootstrap
+    mkdir build
+    pushd build
+    ../configure --enable-static=yes --enable-shared=no --with-pic --prefix="$OPENEXR_DIR" --with-ilmbase-prefix="$ILMBASE_DIR" && make && make install
+    popd
+    popd
+
+    popd
+  fi
 before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&
   export PATH=$HOME/.local/bin:$PATH
 script:
 - |
+  ILMBASE_DIR="$PWD/ilmbase" OPENEXR_DIR="$PWD/openexr" \
   travis-cargo build &&
   travis-cargo test &&
   travis-cargo --only stable doc
 after_success:
 - travis-cargo --only stable doc-upload
+
+cache:
+  pip: true
+  cargo: true
+  directories:
+  - ilmbase
+  - openexr


### PR DESCRIPTION
This should considerably reduce CI latency.

I switched the build to autotools because the cmake build in 2.2 is buggy.