### PR TITLE
envmap accessors

### DIFF
--- a/openexr-sys/c_wrapper/cexr.cpp
+++ b/openexr-sys/c_wrapper/cexr.cpp
@@ -11,6 +11,7 @@
 #include "ImfOutputFile.h"
 #include "ImfInputFile.h"
 #include "Iex.h"
+#include "ImfStandardAttributes.h"
 
 #include "memory_istream.hpp"
 #include "rust_istream.hpp"
@@ -168,6 +169,22 @@ void CEXR_Header_set_line_order(CEXR_Header *header, CEXR_LineOrder line_order) 
 
 void CEXR_Header_set_compression(CEXR_Header *header, CEXR_Compression compression) {
     *reinterpret_cast<CEXR_Compression *>(&reinterpret_cast<Header *>(header)->compression()) = compression;
+}
+
+bool CEXR_Header_has_envmap(const CEXR_Header *header) {
+    return hasEnvmap(*reinterpret_cast<const Header *>(header));
+}
+
+int CEXR_Header_envmap(const CEXR_Header *header) {
+    return envmap(*reinterpret_cast<const Header *>(header));
+}
+
+void CEXR_Header_set_envmap(CEXR_Header *header, int envmap) {
+    addEnvmap(*reinterpret_cast<Header *>(header), static_cast<Imf::Envmap>(envmap));
+}
+
+void CEXR_Header_unset_envmap(CEXR_Header *header) {
+    reinterpret_cast<Header *>(header)->erase("envmap");
 }
 
 

--- a/openexr-sys/c_wrapper/cexr.cpp
+++ b/openexr-sys/c_wrapper/cexr.cpp
@@ -183,8 +183,8 @@ void CEXR_Header_set_envmap(CEXR_Header *header, int envmap) {
     addEnvmap(*reinterpret_cast<Header *>(header), static_cast<Imf::Envmap>(envmap));
 }
 
-void CEXR_Header_unset_envmap(CEXR_Header *header) {
-    reinterpret_cast<Header *>(header)->erase("envmap");
+void CEXR_Header_erase_attribute(CEXR_Header *header, const char *attribute) {
+    reinterpret_cast<Header *>(header)->erase(attribute);
 }
 
 

--- a/openexr-sys/c_wrapper/cexr.h
+++ b/openexr-sys/c_wrapper/cexr.h
@@ -201,7 +201,7 @@ void CEXR_Header_set_compression(CEXR_Header *header, CEXR_Compression compressi
 bool CEXR_Header_has_envmap(const CEXR_Header *header);
 int CEXR_Header_envmap(const CEXR_Header *header);
 void CEXR_Header_set_envmap(CEXR_Header *header, int envmap);
-void CEXR_Header_unset_envmap(CEXR_Header *header);
+void CEXR_Header_erase_attribute(CEXR_Header *header, const char *attribute);
 
 
 CEXR_FrameBuffer *CEXR_FrameBuffer_new();

--- a/openexr-sys/c_wrapper/cexr.h
+++ b/openexr-sys/c_wrapper/cexr.h
@@ -198,6 +198,10 @@ void CEXR_Header_set_screen_window_center(CEXR_Header *header, CEXR_V2f center);
 void CEXR_Header_set_screen_window_width(CEXR_Header *header, float width);
 void CEXR_Header_set_line_order(CEXR_Header *header, CEXR_LineOrder line_order);
 void CEXR_Header_set_compression(CEXR_Header *header, CEXR_Compression compression);
+bool CEXR_Header_has_envmap(const CEXR_Header *header);
+int CEXR_Header_envmap(const CEXR_Header *header);
+void CEXR_Header_set_envmap(CEXR_Header *header, int envmap);
+void CEXR_Header_unset_envmap(CEXR_Header *header);
 
 
 CEXR_FrameBuffer *CEXR_FrameBuffer_new();

--- a/openexr-sys/src/bindings.rs
+++ b/openexr-sys/src/bindings.rs
@@ -403,7 +403,9 @@ extern "C" {
                                   envmap: ::std::os::raw::c_int);
 }
 extern "C" {
-    pub fn CEXR_Header_unset_envmap(header: *mut CEXR_Header);
+    pub fn CEXR_Header_erase_attribute(header: *mut CEXR_Header,
+                                       attribute:
+                                           *const ::std::os::raw::c_char);
 }
 extern "C" {
     pub fn CEXR_FrameBuffer_new() -> *mut CEXR_FrameBuffer;

--- a/openexr-sys/src/bindings.rs
+++ b/openexr-sys/src/bindings.rs
@@ -392,6 +392,20 @@ extern "C" {
                                        compression: CEXR_Compression);
 }
 extern "C" {
+    pub fn CEXR_Header_has_envmap(header: *const CEXR_Header) -> bool;
+}
+extern "C" {
+    pub fn CEXR_Header_envmap(header: *const CEXR_Header)
+     -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn CEXR_Header_set_envmap(header: *mut CEXR_Header,
+                                  envmap: ::std::os::raw::c_int);
+}
+extern "C" {
+    pub fn CEXR_Header_unset_envmap(header: *mut CEXR_Header);
+}
+extern "C" {
     pub fn CEXR_FrameBuffer_new() -> *mut CEXR_FrameBuffer;
 }
 extern "C" {

--- a/src/header.rs
+++ b/src/header.rs
@@ -239,7 +239,7 @@ impl Header {
         if let Some(x) = envmap {
             unsafe { CEXR_Header_set_envmap(self.handle, x as c_int) }
         } else {
-            unsafe { CEXR_Header_unset_envmap(self.handle) }
+            unsafe { CEXR_Header_erase_attribute(self.handle, b"envmap\0".as_ptr() as *const _) }
         }
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,6 @@ pub mod output;
 pub use cexr_type_aliases::{PixelType, Box2i};
 pub use error::{Result, Error};
 pub use frame_buffer::{FrameBuffer, FrameBufferMut};
-pub use header::Header;
+pub use header::{Header, Envmap};
 pub use input::InputFile;
 pub use output::ScanlineOutputFile;


### PR DESCRIPTION
Unfortunately, OpenEXR distinguishes attributes with RTTI, which makes it difficult to define a simple FFI boundary that works for arbitrary attributes.