### PR TITLE
Clippy fixes, add to run Clippy on nightly builds on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 target
 Cargo.lock
 .vscode
+*.exr
+*.swp
+*.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ rust:
 - stable
 - beta
 - nightly
+matrix:
+    allow_failures:
+        - rust: nightly
 env:
   global:
     - MAKEFLAGS="-j 2"
-    - TRAVIS_CARGO_NIGHTLY_FEATURE=""
     - secure: HymLL+xGbR8WmBN7j5c/dNgCZ7WtLInNNDyqQKYA3Y0bEDTF4s26Q06YDrEuJtIsAvXCBxiNxONb4PYTqXTOBl6chc8BXGQoRx7tQBo9KXlV4DLwGiKSpl5/tmDsBXublFGAO1hh+tXjhgL6vA2kgLfvHq3rYV2eEioGEHXC4UOxdbEgPLeZ2FxqZrQuG9b4+tL8hjUuvZP26NgR23y80nnubAoiJb/qSwgtDdDaslBpU7/kQI5HU6C3Kt45feIGFhmYAPNVUjV4DyzT7d3tvZopcITTlBqMDAgYj0bYUF79c6FSQ7iDVJAh4ZQ3G0hXvzTe5IIaQ+BazG8yNSm4RY4R9MS0SkiVKT82LXYEtglPDO0QFL753QxGktkSfPFwhqK9AFIyJYXDGehqhpfA9ZR4innMANejWYNE5MB0XfSPuUsl2yKsxwoEWeDx5BkiiZj0IhwqAb2Y6fHdVgRMdsOVUHm06BMzVmBgVed0SNzdrfaqECxH5uIbGPWShiTJQmD82y2Bf/0qYPe42mNpAdEIcW6/Kf+emZMhkwS1a7W9Kkls6k8LykdJxQ00Ico6OTQd2Zr3t99aQQ3uRpQwkDS2Qo1GV2P3BGnkhUEesZxKctfYVpHFg+5F5eVOQ4knZskLQW5ha0dTnX8jIjdFnJQU36M1psrt4fdkTgwc44A=
 
 before_install:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,12 @@ keywords = ["OpenEXR"]
 [dependencies]
 libc = "0.2"
 half = "1"
+clippy = { version = "*", optional = true }
 
 [dependencies.openexr-sys]
 path = "openexr-sys"
 version = "0.5.0"
+
+[features]
+unstable = ["clippy"]
+

--- a/examples/half_output.rs
+++ b/examples/half_output.rs
@@ -16,7 +16,7 @@ fn main() {
         .unwrap();
 
     let mut exr_file = ScanlineOutputFile::new(&mut file,
-                                               &Header::new()
+                                               Header::new()
                                                     .set_resolution(256, 256)
                                                     .add_channel("R", PixelType::HALF)
                                                     .add_channel("G", PixelType::HALF)

--- a/examples/simple_input.rs
+++ b/examples/simple_input.rs
@@ -14,12 +14,12 @@ fn main() {
     let (width, height) = exr_file.header().data_dimensions();
 
     // Make sure the channels we want exist in the file
-    for channel_name in ["R", "G", "B"].iter() {
+    for channel_name in &["R", "G", "B"] {
         let channel = exr_file
             .header()
             .get_channel(channel_name)
             .expect(&format!("Didn't find channel {}.", channel_name));
-        assert!(channel.pixel_type == PixelType::FLOAT);
+        assert_eq!(channel.pixel_type, PixelType::FLOAT);
     }
 
     // Create our pixel data buffer and load the data from the file

--- a/openexr-sys/build.rs
+++ b/openexr-sys/build.rs
@@ -76,7 +76,7 @@ fn main() {
     }
 
     // Build C wrapper for OpenEXR
-    let mut gcc = gcc::Config::new();
+    let mut gcc = gcc::Build::new();
     gcc.cpp(true).include("c_wrapper");
     #[cfg(target_env = "msvc")]
     gcc.flag("/std:c++14");

--- a/src/frame_buffer.rs
+++ b/src/frame_buffer.rs
@@ -1,4 +1,4 @@
-//! FrameBuffers point to and describe image data in memory to be used for
+//! A `FrameBuffer` points to and describes image data in memory to be used for
 //! input and output.
 //!
 //! FrameBuffers do not contain any image buffers themselves, they only point to
@@ -28,7 +28,7 @@
 
 use std::ffi::CString;
 use std::marker::PhantomData;
-use std::mem;
+use std::{mem, ptr};
 use std::ops::Deref;
 
 use half::f16;
@@ -403,7 +403,7 @@ unsafe impl<T: PixelData> PixelStruct for T {
 
 macro_rules! offset_of {
     ($ty:ty, $field:tt) => {
-        unsafe { &(*(0 as *const $ty)).$field as *const _ as usize }
+        unsafe { &(*(ptr::null() as *const $ty)).$field as *const _ as usize }
     }
 }
 

--- a/src/frame_buffer.rs
+++ b/src/frame_buffer.rs
@@ -403,7 +403,7 @@ unsafe impl<T: PixelData> PixelStruct for T {
 
 macro_rules! offset_of {
     ($ty:ty, $field:tt) => {
-        unsafe { &(*(ptr::null() as *const $ty)).$field as *const _ as usize }
+        unsafe { &(*(0 as *const $ty)).$field as *const _ as usize }
     }
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -55,7 +55,7 @@ impl Header {
             let screen_window_width = 1.0;
             let line_order = LineOrder::INCREASING_Y;
             let compression = Compression::PIZ_COMPRESSION;
-            let header = unsafe {
+            unsafe {
                 CEXR_Header_new(&display_window,
                                 &data_window,
                                 pixel_aspect_ratio,
@@ -63,8 +63,7 @@ impl Header {
                                 screen_window_width,
                                 line_order,
                                 compression)
-            };
-            header
+            }
         };
 
         Self {
@@ -202,7 +201,7 @@ impl Header {
     }
 
     /// Returns an iterator over the channels in the header.
-    pub fn channels<'a>(&'a self) -> ChannelIter<'a> {
+    pub fn channels(&self) -> ChannelIter {
         ChannelIter {
             iterator: unsafe { CEXR_Header_channel_list_iter(self.handle) },
             _phantom_1: PhantomData,
@@ -214,7 +213,7 @@ impl Header {
     pub fn get_channel<'a>(&'a self, name: &str) -> Option<&'a Channel> {
         let c_name = CString::new(name.as_bytes()).unwrap();
         let out = unsafe { CEXR_Header_get_channel(self.handle, c_name.as_ptr()) };
-        if out != std::ptr::null() {
+        if !out.is_null() {
             Some(unsafe { &(*out) })
         } else {
             None
@@ -292,6 +291,12 @@ impl Header {
         }
 
         Ok(())
+    }
+}
+
+impl Default for Header {
+    fn default() -> Header {
+        Header::new()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!   [`FrameBufferMut`](frame_buffer/struct.FrameBufferMut.html):
 //!   these are intermediaries that tell the OpenEXR APIs how to interpret
 //!   your in-memory image data.  Rather than passing your image data to the
-//!   APIs directly, you construct a FrameBuffer that that points at and
+//!   APIs directly, you construct a `FrameBuffer` that that points at and
 //!   describes it, and then you pass that FrameBuffer.
 //!
 //! # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@
 
 
 #![warn(missing_docs)]
+#![cfg_attr(feature = "unstable", feature(plugin))]
+#![cfg_attr(feature = "unstable", plugin(clippy))]
 
 extern crate half;
 extern crate libc;

--- a/src/stream_io.rs
+++ b/src/stream_io.rs
@@ -13,14 +13,14 @@ pub unsafe extern "C" fn read_stream<T: Read>(read: *mut c_void,
                                               -> c_int {
     let bytes = slice::from_raw_parts_mut(c as *mut u8, n as usize);
     match (*(read as *mut T)).read_exact(bytes) {
-        Ok(_) => return 0,
+        Ok(_) => 0,
         Err(e) => {
             if let Some(err) = e.raw_os_error() {
                 *err_out = err as c_int;
-                return 1;
+                1
             } else {
                 *err_out = 0;
-                return 2;
+                2
             }
         }
     }
@@ -37,14 +37,14 @@ pub unsafe extern "C" fn write_stream<T: Write>(writer: *mut c_void,
                                                 -> c_int {
     let bytes = slice::from_raw_parts(c as *const u8, n as usize);
     match (*(writer as *mut T)).write_all(bytes) {
-        Ok(_) => return 0,
+        Ok(_) => 0,
         Err(e) => {
             if let Some(err) = e.raw_os_error() {
                 *err_out = err as c_int;
-                return 1;
+                1
             } else {
                 *err_out = 0;
-                return 2;
+                2
             }
         }
     }
@@ -59,14 +59,14 @@ pub unsafe extern "C" fn seek_stream<T: Seek>(seeker: *mut c_void,
                                               err_out: *mut c_int)
                                               -> c_int {
     match (*(seeker as *mut T)).seek(SeekFrom::Start(pos)) {
-        Ok(_) => return 0,
+        Ok(_) => 0,
         Err(e) => {
             if let Some(err) = e.raw_os_error() {
                 *err_out = err as c_int;
-                return 1;
+                1
             } else {
                 *err_out = 0;
-                return 2;
+                2
             }
         }
     }

--- a/tests/incremental_io.rs
+++ b/tests/incremental_io.rs
@@ -28,7 +28,7 @@ fn incremental_io() {
                                           .insert_channels(&["R", "G", "B"], &pixel_data))
             .unwrap();
 
-        for pixel in pixel_data.iter_mut() {
+        for pixel in &mut pixel_data {
             *pixel = (0.0, 1.0, 0.0);
         }
 
@@ -37,7 +37,7 @@ fn incremental_io() {
                                           .insert_channels(&["R", "G", "B"], &pixel_data))
             .unwrap();
 
-        for pixel in pixel_data.iter_mut() {
+        for pixel in &mut pixel_data {
             *pixel = (0.0, 0.0, 1.0);
         }
 
@@ -46,7 +46,7 @@ fn incremental_io() {
                                           .insert_channels(&["R", "G", "B"], &pixel_data))
             .unwrap();
 
-        for pixel in pixel_data.iter_mut() {
+        for pixel in &mut pixel_data {
             *pixel = (1.0, 1.0, 1.0);
         }
 
@@ -63,14 +63,14 @@ fn incremental_io() {
         let (width, height) = exr_file.header().data_dimensions();
 
         // Make sure the image properties are the same.
-        assert!(width == 256);
-        assert!(height == 256);
-        for channel_name in ["R", "G", "B"].iter() {
+        assert_eq!(width, 256);
+        assert_eq!(height, 256);
+        for channel_name in &["R", "G", "B"] {
             let channel = exr_file
                 .header()
                 .get_channel(channel_name)
                 .expect(&format!("Didn't find channel {}.", channel_name));
-            assert!(channel.pixel_type == PixelType::FLOAT);
+            assert_eq!(channel.pixel_type, PixelType::FLOAT);
         }
 
         // Read in the pixel data in four chunks, verifying that each has

--- a/tests/memory_io.rs
+++ b/tests/memory_io.rs
@@ -14,7 +14,7 @@ fn memory_io() {
         let pixel_data = vec![(0.82f32, 1.78f32, 0.21f32); 256 * 256];
 
         let mut exr_file = ScanlineOutputFile::new(&mut in_memory_buffer,
-                                                   &Header::new()
+                                                   Header::new()
                                                         .set_resolution(256, 256)
                                                         .add_channel("R", PixelType::FLOAT)
                                                         .add_channel("G", PixelType::FLOAT)
@@ -24,7 +24,7 @@ fn memory_io() {
         let mut fb = FrameBuffer::new(256, 256);
         fb.insert_channels(&["R", "G", "B"], &pixel_data);
 
-        exr_file.write_pixels(&mut fb).unwrap();
+        exr_file.write_pixels(&fb).unwrap();
     }
 
     // Read file from memory, and verify its contents
@@ -35,14 +35,14 @@ fn memory_io() {
         let (width, height) = exr_file.header().data_dimensions();
 
         // Make sure the image properties are the same.
-        assert!(width == 256);
-        assert!(height == 256);
-        for channel_name in ["R", "G", "B"].iter() {
+        assert_eq!(width, 256);
+        assert_eq!(height, 256);
+        for channel_name in &["R", "G", "B"] {
             let channel = exr_file
                 .header()
                 .get_channel(channel_name)
                 .expect(&format!("Didn't find channel {}.", channel_name));
-            assert!(channel.pixel_type == PixelType::FLOAT);
+            assert_eq!(channel.pixel_type, PixelType::FLOAT);
         }
 
         // Read in the pixel data.


### PR DESCRIPTION
This PR fixes some various lints from [clippy](https://github.com/rust-lang-nursery/rust-clippy) and adds the `unstable` feature to run clippy on Travis builds with the nightly compiler as well, to pick up new lints on each commit.

I've left some clippy lints unfixed (about the documentation formatting, and some on too many params for a function), but can do these as well. I think the "too many args for function" ones are actually ok.