### PR TITLE
Expose setGlobalThreadCount()

### DIFF
--- a/openexr-sys/c_wrapper/cexr.cpp
+++ b/openexr-sys/c_wrapper/cexr.cpp
@@ -12,6 +12,7 @@
 #include "ImfInputFile.h"
 #include "Iex.h"
 #include "ImfStandardAttributes.h"
+#include "ImfThreading.h"
 
 #include "memory_istream.hpp"
 #include "rust_istream.hpp"
@@ -354,4 +355,9 @@ int CEXR_OutputFile_write_pixels(CEXR_OutputFile *file, int num_scanlines, const
         return 1;
     }
     return 0;
+}
+
+
+void CEXR_set_global_thread_count(int thread_count) {
+    setGlobalThreadCount(thread_count);
 }

--- a/openexr-sys/c_wrapper/cexr.h
+++ b/openexr-sys/c_wrapper/cexr.h
@@ -233,6 +233,7 @@ const CEXR_Header *CEXR_OutputFile_header(CEXR_OutputFile *file);
 int CEXR_OutputFile_set_framebuffer(CEXR_OutputFile *file, const CEXR_FrameBuffer *framebuffer, const char **err_out);
 int CEXR_OutputFile_write_pixels(CEXR_OutputFile *file, int num_scanlines, const char **err_out);
 
+void CEXR_set_global_thread_count(int thread_count);
 
 #ifdef __cplusplus
 }

--- a/openexr-sys/src/bindings.rs
+++ b/openexr-sys/src/bindings.rs
@@ -507,3 +507,6 @@ extern "C" {
                                             *mut *const ::std::os::raw::c_char)
      -> ::std::os::raw::c_int;
 }
+extern "C" {
+    pub fn CEXR_set_global_thread_count(thread_count: ::std::os::raw::c_int);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,3 +111,13 @@ pub use frame_buffer::{FrameBuffer, FrameBufferMut};
 pub use header::{Header, Envmap};
 pub use input::InputFile;
 pub use output::ScanlineOutputFile;
+
+/// Set the number of worker threads to use for doing I/O.
+///
+/// If set to 0, multi-threaded I/O is disabled.
+pub fn set_global_thread_count(thread_count: i32) {
+    use openexr_sys::CEXR_set_global_thread_count;
+    unsafe {
+        CEXR_set_global_thread_count(thread_count);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,12 +112,19 @@ pub use header::{Header, Envmap};
 pub use input::InputFile;
 pub use output::ScanlineOutputFile;
 
-/// Set the number of worker threads to use for doing I/O.
+/// Set the number of worker threads to use for compression/decompression.
 ///
-/// If set to 0, multi-threaded I/O is disabled.
-pub fn set_global_thread_count(thread_count: i32) {
+/// This controls the maximum number of work threads that can be used to perform
+/// compression,decompression while loading or writing a file. Note that the file I/O itself is
+/// always performed on the calling thread. If this value is set to 0, multi-threaded is disabled
+/// globally.
+pub fn set_global_thread_count(thread_count: u32) {
     use openexr_sys::CEXR_set_global_thread_count;
+    assert!(
+        thread_count <= ::std::os::raw::c_int::max_value() as u32,
+        "The number of threads is too high"
+    );
     unsafe {
-        CEXR_set_global_thread_count(thread_count);
+        CEXR_set_global_thread_count(thread_count as ::std::os::raw::c_int);
     }
 }


### PR DESCRIPTION
This function can be used to configure the number of worker threads used
for multi-threaded I/O.

Note: I've never done any C FFI before, so I have no idea if I've done the right thing :)

Addresses issue #25 