### PR TITLE
Add suffix to Half library name

### DIFF
--- a/openexr-sys/build.rs
+++ b/openexr-sys/build.rs
@@ -45,7 +45,7 @@ fn main() {
             println!("cargo:rustc-link-lib=static=Iex{}", suffix);
             println!("cargo:rustc-link-lib=static=Imath{}", suffix);
             println!("cargo:rustc-link-lib=static=IlmThread{}", suffix);
-            println!("cargo:rustc-link-lib=static=Half");
+            println!("cargo:rustc-link-lib=static=Half{}", suffix);
             include_paths.push(PathBuf::from(&format!("{}/include/OpenEXR", path)));
         } else {
             let paths = pkg_config::Config::new()


### PR DESCRIPTION
This was necessary for me to build on macOS.