### PR TITLE
Fix #42: uninitialized panic in Rust-nightly

### DIFF
--- a/src/frame_buffer.rs
+++ b/src/frame_buffer.rs
@@ -212,10 +212,10 @@ impl<'a> FrameBuffer<'a> {
     // about a FrameBuffer Slice.  For internal use only.
     pub(crate) fn _get_channel(&self, name: &str) -> Option<Channel> {
         let c_name = CString::new(name.as_bytes()).unwrap();
-        let mut channel = unsafe { mem::uninitialized() };
-        if unsafe { CEXR_FrameBuffer_get_channel(self.handle, c_name.as_ptr(), &mut channel) } == 0
+        let mut channel = mem::MaybeUninit::uninit();
+        if unsafe { CEXR_FrameBuffer_get_channel(self.handle, c_name.as_ptr(), channel.as_mut_ptr()) } == 0
         {
-            Some(channel)
+            Some(unsafe { channel.assume_init() })
         } else {
             None
         }

--- a/src/header.rs
+++ b/src/header.rs
@@ -353,15 +353,15 @@ impl<'a> Drop for ChannelIter<'a> {
 impl<'a> Iterator for ChannelIter<'a> {
     type Item = Result<(&'a str, Channel)>;
     fn next(&mut self) -> Option<Result<(&'a str, Channel)>> {
-        let mut name = unsafe { std::mem::uninitialized() };
-        let mut channel = unsafe { std::mem::uninitialized() };
-        if unsafe { CEXR_ChannelListIter_next(self.iterator, &mut name, &mut channel) } {
+        let mut name = std::mem::MaybeUninit::uninit();
+        let mut channel = std::mem::MaybeUninit::uninit();
+        if unsafe { CEXR_ChannelListIter_next(self.iterator, name.as_mut_ptr(), channel.as_mut_ptr()) } {
             // TODO: use CStr::from_bytes_with_nul() instead to avoid memory unsafety
             // if the string is not nul terminated.
-            let cname = unsafe { CStr::from_ptr(name) };
+            let cname = unsafe { CStr::from_ptr(name.assume_init()) };
             let str_name = cname.to_str();
             if let Ok(n) = str_name {
-                Some(Ok((n, channel)))
+                Some(Ok((n, unsafe { channel.assume_init() })))
             } else {
                 Some(Err(Error::Generic(format!(
                     "Invalid channel name: {:?}",


### PR DESCRIPTION
I have replaced three instances of  `mem::uninitialized()`  with `mem::MaybeUninit::uninit()`. 

I have followed doc guidance from https://doc.rust-lang.org/std/mem/union.MaybeUninit.html and `cargo test` no longer leads to crash. However, It's the first time I've used `MaybeUninit` so a review is in order.